### PR TITLE
Avoiding connectionstring issues in Integration Testing DB

### DIFF
--- a/1.Domain/Domain.IntegrationTests/Core/BaseServiceIntegrationTest.cs
+++ b/1.Domain/Domain.IntegrationTests/Core/BaseServiceIntegrationTest.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using Xunit;
 using Microsoft.AspNetCore.TestHost;
+using Domain.Services.Repositories.EF;
 
 namespace Domain.Services.Impl.IntegrationTests.Core
 {
@@ -12,11 +13,15 @@ namespace Domain.Services.Impl.IntegrationTests.Core
         protected TestServer Server { get; }
         protected IServiceProvider Services { get;  }
 
+        protected DataBaseContext Context { get;  }
+
         public BaseServiceIntegrationTest(ServiceFixture serviceFixture)
         {
             Client = serviceFixture.Client;
             Server = serviceFixture.Server;
             Services = serviceFixture.Server.Host.Services;
+            Context = serviceFixture.Server.Host.Services.GetService(typeof(DataBaseContext)) as DataBaseContext;
+            Context.Database.EnsureCreated();
         }
     }
 }

--- a/4.Clients/ApiServer.FunctionalTests/Controller/AuthControllerFunctionalTest.cs
+++ b/4.Clients/ApiServer.FunctionalTests/Controller/AuthControllerFunctionalTest.cs
@@ -21,6 +21,8 @@ namespace ApiServer.FunctionalTests.Controller
         public async Task GivenValidLoginData_ShouldReturnOk()
         {
             //Arrange
+            Context.Users.Add(new Domain.Model.User { Username = "nicolas.roldan@softvision.com", Password = "03AC674216F3E15C761EE1A5E255F067953623C8B388B4459E13F978D7C846F4" });
+            Context.SaveChanges();
             var model = new LoginViewModelBuilder().GetValidData();
 
             //Act

--- a/4.Clients/ApiServer.FunctionalTests/Core/ApiFixture.cs
+++ b/4.Clients/ApiServer.FunctionalTests/Core/ApiFixture.cs
@@ -23,9 +23,7 @@ namespace ApiServer.FunctionalTests.Core
                 {
                     var builder = new ConfigurationBuilder()
                         .SetBasePath(Directory.GetCurrentDirectory())
-                        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                        .AddJsonFile($"appsettings.{_env}.json", optional: false, reloadOnChange: true)
-                        .AddEnvironmentVariables();
+                        .AddJsonFile($"appsettings.{_env}.json", optional: false, reloadOnChange: true);
 
                     Server = new TestServer(WebHost.CreateDefaultBuilder()
                         .UseEnvironment(_env)

--- a/4.Clients/ApiServer.FunctionalTests/Core/BaseApiTest.cs
+++ b/4.Clients/ApiServer.FunctionalTests/Core/BaseApiTest.cs
@@ -21,6 +21,7 @@ namespace ApiServer.FunctionalTests.Core
         {
             Client = apiFixture.Client;
             Context = apiFixture.Server.Host.Services.GetService(typeof(DataBaseContext)) as DataBaseContext;
+            Context.Database.EnsureCreated();
         }
 
         protected static void AssertSuccess(HttpResponseMessage response, string responseString)

--- a/4.Clients/ApiServer.FunctionalTests/Core/BaseApiTest.cs
+++ b/4.Clients/ApiServer.FunctionalTests/Core/BaseApiTest.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Core;
+using Domain.Services.Repositories.EF;
 
 namespace ApiServer.FunctionalTests.Core
 {
@@ -14,10 +15,12 @@ namespace ApiServer.FunctionalTests.Core
         protected HttpClient Client { get; }
 
         protected string ControllerName { get; set; }
+        protected DataBaseContext Context {get;}
 
         public BaseApiTest(ApiFixture apiFixture)
         {
             Client = apiFixture.Client;
+            Context = apiFixture.Server.Host.Services.GetService(typeof(DataBaseContext)) as DataBaseContext;
         }
 
         protected static void AssertSuccess(HttpResponseMessage response, string responseString)


### PR DESCRIPTION
>Changed logic to ensure that database is created if it not exists
>Deleted configurations related to development environment to ensure that uses only the connectionstring from appsettings.IntegrationTest 
>Small fixes to avoid falling tests