### PR TITLE
bug/rename_dashboard_controller_request_parameters

### DIFF
--- a/4.Clients/ApiServer/Controllers/DashboardController.cs
+++ b/4.Clients/ApiServer/Controllers/DashboardController.cs
@@ -34,7 +34,7 @@ namespace ApiServer.Controllers
             });
         }
 
-        [HttpGet("{Id}")]
+        [HttpGet("{id}")]
         public IActionResult Get(int id)
         {
             return ApiAction(() =>
@@ -66,7 +66,7 @@ namespace ApiServer.Controllers
 
         // PUT api/dashboard/5
         // Mutation
-        [HttpPut("{Id}")]
+        [HttpPut("{id}")]
         public IActionResult Put(int id, [FromBody]UpdateDashboardViewModel vm)
         {
             return ApiAction(() =>
@@ -80,7 +80,7 @@ namespace ApiServer.Controllers
         }
 
         // DELETE api/dashboard/5
-        [HttpDelete("{Id}")]
+        [HttpDelete("{id}")]
         public IActionResult Delete(int id)
         {
             return ApiAction(() =>


### PR DESCRIPTION
Changed the request parameters in the ApiServer/DashboardController, from "Id" to "id", to match the parameter names of each method