### PR TITLE
ReferredBy null check adjustment

### DIFF
--- a/1.Domain/Domain.Services.Impl/Services/ProcessService.cs
+++ b/1.Domain/Domain.Services.Impl/Services/ProcessService.cs
@@ -245,8 +245,8 @@ namespace Domain.Services.Impl.Services
 
             var status = process.Status;
 
-            if (process.Candidate.ReferredBy != null && process.Status == ProcessStatus.Hired || process.Status == ProcessStatus.InProgress 
-                || process.Status == ProcessStatus.OfferAccepted || process.Status == ProcessStatus.Recall)
+            if (process.Candidate.ReferredBy != null && (process.Status == ProcessStatus.Hired || process.Status == ProcessStatus.InProgress 
+                || process.Status == ProcessStatus.OfferAccepted || process.Status == ProcessStatus.Recall))
             {
                 var notification = new Notification
                 {


### PR DESCRIPTION
Card for this bug in trello:
<blockquote class="trello-card"><a href="https://trello.com/c/3lA4MiN2/140-referredby-null-error-when-saving-existing-candidate">ReferredBy null error when saving existing candidate</a></blockquote>