### PR TITLE
Added script to migrate both databases on a single run

### DIFF
--- a/DBProject/DB-Update.ps1
+++ b/DBProject/DB-Update.ps1
@@ -1,0 +1,22 @@
+param(
+    [Parameter(Mandatory=$False, Position=0)]
+    [System.String]
+    $Migration
+)
+
+Write-Host "Begin: updating databases" `n -ForegroundColor cyan
+
+$ProjectName = "ApiServer"
+$DevelopmentEnvironment = "Development"
+$IntegrationEnvironment = "IntegrationTest"
+$EnvArray = $DevelopmentEnvironment, $IntegrationEnvironment
+
+foreach ($Env in $EnvArray){  
+    $env:ASPNETCORE_ENVIRONMENT = $Env
+    Write-Host "ASPNETCORE_ENVIRONMENT is now: "$Env `n -ForegroundColor cyan
+    Write-Host "Updating database with environment : " $Env `n -ForegroundColor cyan            
+    update-database $Migration
+}
+
+$env:ASPNETCORE_ENVIRONMENT = $DevelopmentEnvironment
+Write-Host "End: Updated databases, ASPNETCORE_ENVIRONMENT is $env:ASPNETCORE_ENVIRONMENT" `n -ForegroundColor green

--- a/DBProject/DBProject.sqlproj
+++ b/DBProject/DBProject.sqlproj
@@ -85,5 +85,6 @@
   <ItemGroup>
     <None Include="Compare_Local_To_Project.scmp" />
     <None Include="Scripts\001-seed.sql" />
+    <None Include="DB-Update.ps1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What is this fix/feature about?
I've created a small script that handles the convertion of both integration test, and development databases to a given migration

**This PR is blocked by the following PR:** none

## Ticket
**NetCoreApi trello card URL:** no card

## Type of change
*To mark an option, replace white space with an "x" inside the brackets. This way: [x]*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## I have complied with the following:
*To mark an option, replace white space with an "x" inside the brackets. This way: [x]*

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested with data to prove my fix is effective or that my feature works
- [x] New and existing unit/integration/functional tests pass locally with my changes

## Important Note
Usage instructions are avaible on testing wiki